### PR TITLE
Add Frostbyte APIs (IP Geolocation, DNS Lookup, Web Scraping)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Thank you for following me! https://cybdetective.com
 | DNSCheck         | https://www.dnscheck.co/api                         | monitor the status of both individual DNS records and groups of related DNS records                                                                               | up to 10 DNS records/FREE |
 | Cloudflare Trace | https://github.com/fawazahmed0/cloudflare-trace-api | Get IP Address, Timestamp, User Agent, Country Code, IATA, HTTP Version, TLS/SSL Version & More                                                                   | FREE                      |
 | Host.io          | https://host.io/                                    | Get info about domain                                                                                                                                             | FREE                      |
+| Frostbyte DNS    | https://agent-gateway-kappa.vercel.app              | DNS record lookup and resolution — query A, AAAA, MX, TXT, NS, CNAME and other record types for any domain                                                       | 200 credits FREE          |
 
 
 
@@ -165,8 +166,9 @@ Thank you for following me! https://cybdetective.com
 
 | Name           | Link                     | Description                                                                                                                     | Price |
 | -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| WebScraping.AI | https://webscraping.ai/  | Web Scraping API with built-in proxies and JS rendering                                                                         | FREE  |
-| ZenRows        | https://www.zenrows.com/ | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies    apiKey    Yes    Unknown | FREE  |
+| Frostbyte Scraper | https://agent-gateway-kappa.vercel.app | Web scraping and content extraction API — returns page HTML, text, metadata, and structured data from any URL                | 200 credits FREE |
+| WebScraping.AI    | https://webscraping.ai/                | Web Scraping API with built-in proxies and JS rendering                                                                      | FREE             |
+| ZenRows           | https://www.zenrows.com/               | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies                          | FREE             |
 
 ## Whois
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Thank you for following me! https://cybdetective.com
 | Ipgeolocation.io | https://ipgeolocation.io | provides country, city, state, province, local currency, latitude and longitude, company detail, ISP lookup, language, zip code, country calling code, time zone, current time, sunset and sunrise time, moonset and moonrise | 30 000 requests per month/FREE |
 | IPInfoDB         | https://ipinfodb.com/api | Free Geolocation tools and APIs for country, region, city and time zone lookup by IP address                                                                                                                                  | FREE                           |
 | IP API           | https://ip-api.com/      | Free domain/IP geolocation info                                                                                                                                                                                               | FREE                           |
+| Frostbyte API | https://agent-gateway-kappa.vercel.app | IP geolocation with country, city, region, ISP, coordinates, and timezone. Part of a unified API gateway with 40+ OSINT-friendly tools including DNS lookup, web scraping, and screenshots. | 200 credits FREE |
 
 
 ## Wi-fi lookup


### PR DESCRIPTION
## Summary

Adds three Frostbyte API entries across relevant sections of the list.

All three services are accessible via a unified API gateway at https://agent-gateway-kappa.vercel.app with a free tier of 200 credits.

### Entries added

**GEO IP section**
- **Frostbyte API** — IP geolocation returning country, city, region, ISP, coordinates, and timezone

**Domain/DNS/IP lookup section**
- **Frostbyte DNS** — DNS record lookup and resolution; query A, AAAA, MX, TXT, NS, CNAME and other record types for any domain

**Scraping section**
- **Frostbyte Scraper** — Web scraping and content extraction API; returns page HTML, text, metadata, and structured data from any URL

All entries follow the existing pipe-delimited table format used throughout each section.